### PR TITLE
Add mzPAF serialization support for Fragment objects

### DIFF
--- a/examples/fragment.py
+++ b/examples/fragment.py
@@ -231,8 +231,10 @@ def run():
         mzpaf = frag.to_mzpaf()
         print(f"  {mzpaf}")
 
-        # parse back from mzPAF. Mass and monoisotopic info must be provided since this is not stored in the mzPAF string
-        _: pt.Fragment = pt.Fragment.from_mzpaf(mzpaf, mass=frag.mass, monoisotopic=frag.monoisotopic)
+    # serialize() with format parameter also works
+    print("\nUsing serialize(format='mzpaf'):")
+    for frag in fragments[:4]:
+        print(f"  {frag.serialize(format='mzpaf')}")
 
     print("\n" + "=" * 60)
 

--- a/src/peptacular/annotation/frag.py
+++ b/src/peptacular/annotation/frag.py
@@ -1,11 +1,13 @@
 from collections import Counter
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
 from tacular import (
     ELEMENT_LOOKUP,
+    FRAGMENT_ION_LOOKUP,
     ElementInfo,
     IonType,
+    IonTypeProperty,
 )
 
 from ..constants import ModType
@@ -15,6 +17,34 @@ from ..proforma_components import (
 )
 from .mod import Mods
 from .positions import validate_position
+
+# Maps internal ion type value tuples to their neutral loss diff relative to "by" (the default internal fragment).
+# None means no difference from "by".
+_INTERNAL_MASS_DIFFS: dict[tuple[str, str], str | None] = {
+    ("a", "x"): None,
+    ("b", "x"): "+CO",
+    ("c", "x"): "+CHNO",
+    ("a", "y"): "-CO",
+    ("b", "y"): None,
+    ("c", "y"): "+NH",
+    ("a", "z"): "-CHNO",
+    ("b", "z"): "-NH",
+    ("c", "z"): None,
+}
+
+# Maps peptacular variant ion types to their canonical mzPAF series string.
+_ION_TYPE_TO_MZPAF_SERIES: dict[IonType, str] = {
+    IonType.W_VALINE: "w",
+    IonType.D_VALINE: "d",
+    IonType.WB_ISOLEUCINE: "wb",
+    IonType.WB_THREONINE: "wb",
+    IonType.WA_ISOLEUCINE: "wa",
+    IonType.WA_THREONINE: "wa",
+    IonType.DB_ISOLEUCINE: "db",
+    IonType.DB_THREONINE: "db",
+    IonType.DA_ISOLEUCINE: "da",
+    IonType.DA_THREONINE: "da",
+}
 
 
 class Fragment:
@@ -143,6 +173,158 @@ class Fragment:
             "isotopes": self.isotopes,
             "losses": self.losses,
         }
+
+    def serialize(self, format: Literal["default", "mzpaf"] = "default", include_sequence: bool = True) -> str:
+        """Serialize the fragment to a string representation.
+
+        :param format: Output format. ``"default"`` returns the human-readable representation,
+            ``"mzpaf"`` returns the mzPAF (Peak Annotation Format) label string.
+        :type format: Literal["default", "mzpaf"]
+        :param include_sequence: If True, include the peptide sequence in the mzPAF label. Only used for ``"mzpaf"`` format.
+        :type include_sequence: bool
+        :return: The serialized fragment string.
+        :rtype: str
+        """
+        if format == "default":
+            return str(self)
+        elif format == "mzpaf":
+            return self._serialize_mzpaf(include_sequence=include_sequence)
+        else:
+            raise ValueError(f"Unknown format: {format!r}. Use 'default' or 'mzpaf'.")
+
+    def to_mzpaf(self, include_sequence: bool = True) -> str:
+        """Serialize the fragment to an mzPAF (Peak Annotation Format) label string.
+
+        :param include_sequence: If True, include the peptide sequence in the label.
+        :type include_sequence: bool
+        :return: The mzPAF label string (e.g. ``"y3{IDE}^2"``).
+        :rtype: str
+        """
+        return self._serialize_mzpaf(include_sequence=include_sequence)
+
+    def _serialize_mzpaf(self, include_sequence: bool = True) -> str:
+        """Build the mzPAF label string for this fragment."""
+        from .annotation import ProFormaAnnotation
+
+        parts: list[str] = []
+        internal_loss: str | None = None
+
+        if self.ion_type is None:
+            parts.append("?")
+        else:
+            ion_info = FRAGMENT_ION_LOOKUP[self.ion_type]
+
+            if ion_info.properties & (IonTypeProperty.FORWARD | IonTypeProperty.BACKWARD):
+                # Peptide series ions (a, b, c, x, y, z, d, w, da, db, wa, wb)
+                series_str = _ION_TYPE_TO_MZPAF_SERIES.get(ion_info.ion_type, ion_info.ion_type.value)
+                position = self.position if isinstance(self.position, int) else -1
+                parts.append(f"{series_str}{position}")
+
+                if include_sequence and self.parent_sequence is not None:
+                    seq = self.sequence
+                    if seq is not None:
+                        seq_no_charge = ProFormaAnnotation.parse(seq).serialize(exclude_charge=True)
+                        parts.append(f"{{{seq_no_charge}}}")
+
+            elif ion_info.properties & IonTypeProperty.INTERNAL:
+                if ion_info.id == IonType.IMMONIUM:
+                    # Immonium ion: I{amino_acid}[{modification}]
+                    if self.parent_sequence is not None:
+                        seq = self.sequence
+                        if seq is not None:
+                            annot = ProFormaAnnotation.parse(seq)
+                            parts.append(f"I{annot.sequence}")
+
+                            if annot.has_internal_mods_at_index(0):
+                                internal_mods = annot.get_internal_mods_at_index(0)
+                                if len(internal_mods) > 1:
+                                    raise ValueError(f"Multiple internal mods on immonium ion not supported in mzPAF, got {internal_mods}")
+                                if len(internal_mods) == 1 and internal_mods.mods[0].count > 1:
+                                    raise ValueError(f"Multiple occurrences of internal mod on immonium ion not supported in mzPAF, got {internal_mods}")
+                                mods_str = internal_mods.serialize()[1:-1]  # remove surrounding brackets
+                                if mods_str == "":
+                                    raise ValueError(f"Empty modification string for immonium ion is not valid in mzPAF. Internal mods: {internal_mods}")
+                                parts.append(f"[{mods_str}]")
+                        else:
+                            raise ValueError("Immonium ion must have a sequence annotation.")
+                    else:
+                        raise ValueError("Immonium ion must have a parent sequence.")
+                else:
+                    # Internal fragment: m{start}:{end}[{sequence}]
+                    if isinstance(self.position, tuple) and len(self.position) == 2:
+                        start, end = self.position
+                    else:
+                        start, end = -1, -1
+
+                    parts.append(f"m{start}:{end}")
+
+                    if include_sequence and self.parent_sequence is not None:
+                        seq = self.sequence
+                        if seq is not None:
+                            seq_no_charge = ProFormaAnnotation.parse(seq).serialize(exclude_charge=True)
+                            parts.append(f"{{{seq_no_charge}}}")
+
+                    # Add internal mass diff neutral loss
+                    internal_ion_key = tuple(list(ion_info.ion_type.value))
+                    if internal_ion_key in _INTERNAL_MASS_DIFFS:
+                        internal_loss = _INTERNAL_MASS_DIFFS[internal_ion_key]
+                    else:
+                        raise ValueError(f"Internal ion type {ion_info.ion_type} not supported in mzPAF.")
+
+            elif ion_info.properties & IonTypeProperty.INTACT:
+                if ion_info.ion_type == IonType.PRECURSOR:
+                    parts.append("p")
+                else:
+                    raise ValueError(f"Cannot convert intact ion type {ion_info.id} to mzPAF.")
+            else:
+                raise ValueError(f"Cannot convert fragment with ion type {self.ion_type} to mzPAF.")
+
+        # Neutral losses from self.losses
+        if self._losses is not None:
+            for loss_key, count in self._losses.items():
+                if isinstance(loss_key, float | int):
+                    mass_val = float(loss_key) * count
+                    parts.append(f"{mass_val:+.5f}")
+                else:
+                    loss_formula = ChargedFormula.from_string(loss_key, require_formula_prefix=False)
+                    paf_formula = loss_formula.to_mz_paf()
+                    sign = paf_formula[0]
+                    if sign not in ("+", "-"):
+                        raise ValueError(f"Invalid formula sign in loss: {paf_formula}")
+                    mult = 1 if sign == "+" else -1
+                    abs_count = abs(count * mult)
+                    count_str = str(abs_count) if abs_count > 1 else ""
+                    parts.append(f"{sign}{count_str}{paf_formula[1:]}")
+
+        # Internal mass diff loss (from internal fragment type)
+        if internal_loss is not None:
+            parts.append(internal_loss)
+
+        # Isotopes
+        if self._isotopes is not None:
+            if isinstance(self._isotopes, int):
+                count_str = str(self._isotopes) if self._isotopes > 1 else ""
+                parts.append(f"+{count_str}i")
+            elif isinstance(self._isotopes, dict):
+                for elem, count in self._isotopes.items():
+                    count_str = str(count) if count > 1 else ""
+                    parts.append(f"+{count_str}i{elem}")
+
+        # Adducts
+        if self._charge_adducts is not None:
+            adduct_parts: list[str] = []
+            for mod in self.charge_adducts.mods:
+                carrier: GlobalChargeCarrier = mod.value
+                # to_mz_paf() returns "M+Na", we strip the "M" prefix
+                paf_str = carrier.to_mz_paf()
+                adduct_parts.append(paf_str[1:])  # strip "M", keep "+Na"
+            parts.append(f"[M{''.join(adduct_parts)}]")
+
+        # Charge (only if > 1)
+        if self.charge_state > 1:
+            parts.append(f"^{self.charge_state}")
+
+        return "".join(parts)
 
     def __str__(self) -> str:
         parts = []

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -706,5 +706,88 @@ class TestFragment(unittest.TestCase):
         self.assertAlmostEqual(frags[2].mz, pt.mz("P/2", ion_type="by"))
 
 
+class TestFragmentMzPAF(unittest.TestCase):
+    """Test mzPAF serialization of Fragment objects."""
+
+    def test_b_ion_full(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.B, charge=2)
+        self.assertEqual(frag.to_mzpaf(), "b7{PEPTIDE}^2")
+
+    def test_b_ion_position(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.B, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "b3{PEP}^2")
+
+    def test_y_ion_position(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "y3{IDE}^2")
+
+    def test_y_ion_charge_1(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        self.assertEqual(frag.to_mzpaf(), "y3{IDE}")
+
+    def test_immonium(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.IMMONIUM, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "IP^2")
+
+    def test_immonium_with_mod(self):
+        frag = pt.parse("PEP[+10]TIDE/2").frag(ion_type=pt.IonType.IMMONIUM, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "IP[+10]^2")
+
+    def test_internal_by(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.BY, charge=2, position=(3, 5))
+        self.assertEqual(frag.to_mzpaf(), "m3:5{PTI}^2")
+
+    def test_internal_ay(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.AY, charge=2, position=(3, 5))
+        self.assertEqual(frag.to_mzpaf(), "m3:5{PTI}-CO^2")
+
+    def test_precursor(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.PRECURSOR, charge=2)
+        self.assertEqual(frag.to_mzpaf(), "p^2")
+
+    def test_no_sequence(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(include_sequence=False), "y3^2")
+
+    def test_adduct(self):
+        frags = pt.parse("PEPTIDE/2").fragment(ion_types=["y"], charges=["Na:z+1"])
+        self.assertIn("[M+Na]", frags[0].to_mzpaf())
+
+    def test_isotope_c13(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[1])
+        self.assertIn("+i", frags[0].to_mzpaf())
+
+    def test_isotope_c13_x2(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[2])
+        self.assertIn("+2i", frags[0].to_mzpaf())
+
+    def test_isotope_custom(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[{"17O": 2}])
+        self.assertIn("+2i17O", frags[0].to_mzpaf())
+
+    def test_neutral_loss(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], neutral_deltas=["H2O"])
+        labels = [f.to_mzpaf() for f in frags]
+        self.assertTrue(any("-H2O" in label for label in labels))
+
+    def test_serialize_format_default(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        self.assertEqual(frag.serialize(format="default"), str(frag))
+
+    def test_serialize_format_mzpaf(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.serialize(format="mzpaf"), "y3{IDE}^2")
+
+    def test_serialize_invalid_format(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        with self.assertRaises(ValueError):
+            frag.serialize(format="invalid")
+
+    def test_modification_in_sequence(self):
+        frag = pt.parse("PEPT[Phospho]IDE/2").frag(ion_type=pt.IonType.B, charge=2, position=4)
+        label = frag.to_mzpaf()
+        self.assertEqual(label, "b4{PEPT[Phospho]}^2")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
This PR adds support for serializing `Fragment` objects to the mzPAF (Peak Annotation Format) standard, enabling interoperability with other mass spectrometry analysis tools that use this format.

## Key Changes
- **New serialization methods**: Added `to_mzpaf()` and `serialize(format="mzpaf")` methods to the `Fragment` class for converting fragments to mzPAF label strings
- **Ion type mapping**: Created `_ION_TYPE_TO_MZPAF_SERIES` dictionary to map peptacular variant ion types (w, d, wa, wb, da, db) to their canonical mzPAF series strings
- **Internal fragment support**: Added `_INTERNAL_MASS_DIFFS` dictionary to track neutral loss differences for internal fragments relative to the "by" ion type
- **Comprehensive mzPAF support**: Implemented `_serialize_mzpaf()` method that handles:
  - Peptide series ions (a, b, c, x, y, z, d, w, da, db, wa, wb) with position and sequence
  - Immonium ions with optional modifications
  - Internal fragments with start:end positions and mass difference annotations
  - Precursor ions
  - Neutral losses (both formula-based and mass-based)
  - Isotope labels (C13 and custom isotopes)
  - Adducts (e.g., Na+)
  - Charge states
- **Flexible serialization**: The `serialize()` method now accepts a `format` parameter ("default" or "mzpaf") for unified serialization interface
- **Comprehensive test coverage**: Added 18 test cases covering various fragment types, modifications, adducts, isotopes, and neutral losses

## Implementation Details
- The mzPAF serialization properly handles ProForma annotations for sequences, excluding charge information from embedded sequences
- Internal fragments use the notation `m{start}:{end}` with optional mass difference annotations (e.g., `-CO`, `+NH`)
- Immonium ions are serialized as `I{amino_acid}[{modification}]` with validation for multiple modifications
- The implementation validates that internal modifications on immonium ions are properly formatted for mzPAF output
- Adducts are extracted from charge carriers and formatted as `[M+adduct]` notation

https://claude.ai/code/session_01XAufjCzSekxdHDtPXwix7r