### PR TITLE
Rename fragment_masses to fast_fragment and add mzPAF serialization

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -54,6 +54,26 @@ Create theoretical fragment ions for MS/MS analysis.
 - Neutral losses (H2O, NH3, custom)
 - Isotopes
 
+**Fast Fragment**
+
+For high-throughput workflows, ``fast_fragment()`` uses a prefix/suffix-sum
+algorithm to compute fragment m/z values directly, without constructing
+:class:`~peptacular.Fragment` objects.  It is faster than ``fragment()`` but
+does not support neutral losses, isotope shifts, adduct charges, or custom
+deltas.  Returns a ``dict`` mapping ``(IonType, charge)`` to a list of m/z
+values ordered from fragment position 1 to N.
+
+.. code-block:: python
+
+   import peptacular as pt
+
+   # OOP method
+   mz_map = pt.parse("PEPTIDE").fast_fragment(ion_types=["b", "y"], charges=[1, 2])
+   b1_mzs = mz_map[(pt.IonType.B, 1)]  # list of 7 floats
+
+   # Functional API — supports batch list inputs (auto-parallelised)
+   results = pt.fast_fragment(["PEPTIDE", "ACDEFGHIK"], ion_types=["y"], charges=[1])
+
 Property Calculations
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/fragment.py
+++ b/examples/fragment.py
@@ -199,7 +199,7 @@ def run():
     Unless otherwise specified, fragments do not include sequence or composition data.
     This can be enabled with the `include_sequence` and `calculate_composition` flags.
     """
-    b_ions: list[pt.Fragment] = peptide.fragment(ion_types=["b"], charges=[2], include_sequence=True, calculate_composition=True)
+    b_ions: list[pt.Fragment] = peptide.fragment(ion_types=["b"], charges=[2], calculate_composition=True)
     if len(b_ions) > 0:
         frag = b_ions[0]
         print(f"\nExample fragment: {frag}")
@@ -212,8 +212,6 @@ def run():
         if frag.composition:
             comp_str = {str(elem): count for elem, count in frag.composition.items()}
             print(f"  Composition: {comp_str}")
-        if frag.parent_sequence:
-            print(f"  Sequence: {frag.parent_sequence}")
 
     # ============================================================================
     # MZPAF OUTPUT
@@ -235,6 +233,54 @@ def run():
     print("\nUsing serialize(format='mzpaf'):")
     for frag in fragments[:4]:
         print(f"  {frag.serialize(format='mzpaf')}")
+
+    print("\n" + "=" * 60)
+
+    # ============================================================================
+    # FAST FRAGMENT
+    # ============================================================================
+
+    print("\n" + "=" * 60)
+    print("FAST FRAGMENT")
+    print("=" * 60)
+
+    """
+    fast_fragment() uses a prefix/suffix-sum algorithm to compute fragment m/z
+    values without constructing Fragment objects. It is faster than fragment()
+    for high-throughput use cases.
+
+    Return type: dict[(IonType, charge)] -> list[float]
+    Each list has length == len(peptide), ordered fragment position 1 to N.
+
+    Limitations vs fragment():
+    - No neutral losses (H2O, NH3, custom deltas)
+    - No isotope shifts
+    - No adduct charges (integer charges only)
+    - No internal / immonium ions
+    - Raises if the annotation has unknown or interval modifications
+    """
+
+    peptide = pt.parse("PEPT[Phospho]IDE")
+
+    # --- OOP method ---
+    mz_map = peptide.fast_fragment(ion_types=["b", "y"], charges=[1, 2])
+    print(f"\nPeptide: {peptide}")
+    for (ion_type, charge), mzs in mz_map.items():
+        print(f"  ({ion_type}, z={charge}): {[round(v, 4) for v in mzs]}")
+
+    # --- Functional API (identical result) ---
+    print("\nFunctional API (pt.fast_fragment):")
+    mz_map2 = pt.fast_fragment("PEPTIDE", ion_types=["b", "y"], charges=[1])
+    for (ion_type, charge), mzs in mz_map2.items():
+        print(f"  ({ion_type}, z={charge}): {[round(v, 4) for v in mzs]}")
+
+    # --- Batch / parallel: pass a list of sequences ---
+    print("\nBatch fast_fragment (list input):")
+    sequences = ["PEPTIDE", "ACDEFGHIK", "LMNPQRST"]
+    results = pt.fast_fragment(sequences, ion_types=["y"], charges=[1])
+    for seq, mz_map3 in zip(sequences, results):
+        (ion_type, charge), mzs = next(iter(mz_map3.items()))
+        print(f"  {seq}: {[round(v, 4) for v in mzs]}")
 
     print("\n" + "=" * 60)
 

--- a/examples/fragment.py
+++ b/examples/fragment.py
@@ -231,8 +231,10 @@ def run():
         mzpaf = frag.to_mzpaf()
         print(f"  {mzpaf}")
 
-        # parse back from mzPAF. Mass and monoisotopic info must be provided since this is not stored in the mzPAF string
-        _: pt.Fragment = pt.Fragment.from_mzpaf(mzpaf, mass=frag.mass, monoisotopic=frag.monoisotopic)
+    # serialize() with format parameter also works
+    print("\nUsing serialize(format='mzpaf'):")
+    for frag in fragments[:4]:
+        print(f"  {frag.serialize(format='mzpaf')}")
 
     print("\n" + "=" * 60)
 

--- a/src/peptacular/__init__.py
+++ b/src/peptacular/__init__.py
@@ -17,4 +17,4 @@ from .sequence import *
 from .spans import *
 from .utils import *
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/src/peptacular/annotation/annotation.py
+++ b/src/peptacular/annotation/annotation.py
@@ -2735,7 +2735,7 @@ class ProFormaAnnotation:
         :raises ValueError: If the annotation contains unknown mods or interval mods.
         """
         if self.has_unknown_mods or self.has_intervals:
-            raise ValueError(f"fragment_masses not supported for sequences with unknown modifications or intervals: {str(self)}")
+            raise ValueError(f"fast_fragment not supported for sequences with unknown modifications or intervals: {str(self)}")
 
         aa_lookup = AA_LOOKUP.one_letter_to_info
         masses: list[float] = []
@@ -3324,7 +3324,7 @@ class ProFormaAnnotation:
 
     _UNSUPPORTED_META_ION_TYPES: frozenset[IonType] = frozenset({IonType.W, IonType.D})
 
-    def fragment_masses(
+    def fast_fragment(
         self,
         ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
         charges: Sequence[int] = (1,),
@@ -3352,8 +3352,7 @@ class ProFormaAnnotation:
         for ion_type_input in ion_types:
             if IonType(ion_type_input) in self._UNSUPPORTED_META_ION_TYPES:
                 raise ValueError(
-                    f"Meta ion type {ion_type_input!r} is not supported in fragment_masses(). "
-                    "Pass concrete sub-types (e.g. IonType.WA, IonType.WB) directly."
+                    f"Meta ion type {ion_type_input!r} is not supported in fast_fragment(). Pass concrete sub-types (e.g. IonType.WA, IonType.WB) directly."
                 )
 
         n = len(self)
@@ -3389,10 +3388,7 @@ class ProFormaAnnotation:
                     result[(ion_type, charge)] = [mz] * n
 
                 elif ion_info.is_internal:
-                    result[(ion_type, charge)] = [
-                        (mass_vec[i] + ion_offset + charge_offset) / charge
-                        for i in range(n)
-                    ]
+                    result[(ion_type, charge)] = [(mass_vec[i] + ion_offset + charge_offset) / charge for i in range(n)]
 
         return result
 

--- a/src/peptacular/annotation/annotation.py
+++ b/src/peptacular/annotation/annotation.py
@@ -117,6 +117,7 @@ logger = logging.getLogger(__name__)
 
 fe = FormulaElement(element=Element.H, occurance=1)
 H_CHARGE_FORMULA = ChargedFormula(formula=(fe,), charge=1)
+H_DECHARGE_FORMULA = ChargedFormula(formula=(FormulaElement(element=Element.H, occurance=-1),), charge=-1)
 
 
 ION_TYPE = IonTypeLiteral | IonType
@@ -840,21 +841,22 @@ class ProFormaAnnotation:
 
     @property
     def charge_adducts(self) -> Mods[GlobalChargeCarrier]:
-        """Charge expressed as adduct ``Mods``; converts an integer charge to proton adducts.
+        """Charge expressed as adduct ``Mods``; converts an integer charge to proton/deproton adducts.
+
+        Positive integer charges are converted to proton additions (``[M+nH]n+``);
+        negative integer charges are converted to deprotonations (``[M-nH]n-``).
 
         :rtype: Mods[GlobalChargeCarrier]
         """
         charge = self.charge
         if isinstance(charge, int):
-            if charge == 0 or charge < 0:
+            if charge == 0:
                 return EMPTY_CHARGE_MODS
             elif charge > 0:
-                s = str(
-                    GlobalChargeCarrier(
-                        charged_formula=H_CHARGE_FORMULA,
-                        occurance=charge,
-                    )
-                )
+                s = str(GlobalChargeCarrier(charged_formula=H_CHARGE_FORMULA, occurance=charge))
+                return Mods[GlobalChargeCarrier](mod_type=ModType.CHARGE, _mods={s: 1})
+            else:  # charge < 0
+                s = str(GlobalChargeCarrier(charged_formula=H_DECHARGE_FORMULA, occurance=-charge))
                 return Mods[GlobalChargeCarrier](mod_type=ModType.CHARGE, _mods={s: 1})
         elif isinstance(charge, Mods):
             return charge
@@ -3258,6 +3260,20 @@ class ProFormaAnnotation:
                                         ),
                                     )
 
+    @staticmethod
+    def _default_fragment_charges(charge_state: int) -> tuple[int, ...]:
+        """Return default fragment charge states derived from a precursor charge state.
+
+        For a positive precursor charge ``c``, returns ``1, 2, …, c-1``.
+        For a negative precursor charge ``c``, returns ``-1, -2, …, c+1``.
+        Falls back to ``(1,)`` when ``charge_state`` is 0 (unannotated) or ±1.
+        """
+        if charge_state > 1:
+            return tuple(range(1, charge_state))
+        if charge_state < -1:
+            return tuple(range(-1, charge_state, -1))
+        return (1,)  # charge 0 (unannotated) or ±1 — last resort
+
     def fragment(
         self,
         ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
@@ -3275,11 +3291,7 @@ class ProFormaAnnotation:
         """Generate fragment annotation for given ion type."""
 
         if charges is None:
-            cstate = self.charge_state
-            if cstate != 0:
-                charges = (cstate,)
-            else:
-                charges = (1,)
+            charges = self._default_fragment_charges(self.charge_state)
 
         # charge_infos: list[ChargeCarrierInfo] = [ChargeCarrierInfo.from_input(charge) for charge in charges]
 
@@ -3327,7 +3339,7 @@ class ProFormaAnnotation:
     def fast_fragment(
         self,
         ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
-        charges: Sequence[int] = (1,),
+        charges: Sequence[int] | None = None,
         monoisotopic: bool = True,
     ) -> dict[tuple[IonType, int], list[float]]:
         """Compute fragment ion m/z values using a fast prefix/suffix-sum approach.
@@ -3340,8 +3352,10 @@ class ProFormaAnnotation:
             Meta-types such as ``IonType.W`` and ``IonType.D`` are not supported;
             pass their concrete sub-types (``WA``/``WB``, ``DA``/``DB``) directly.
         :type ion_types: Sequence[ION_TYPE]
-        :param charges: Proton charge states to compute m/z for.
-        :type charges: Sequence[int]
+        :param charges: Proton charge states to compute m/z for.  When ``None``,
+            defaults to ``1`` through ``precursor_charge - 1`` if the annotation
+            carries a positive charge state, otherwise falls back to ``(1,)``.
+        :type charges: Sequence[int] or None
         :param monoisotopic: Use monoisotopic masses when ``True``, average masses when ``False``.
         :type monoisotopic: bool
         :return: Dict mapping ``(IonType, charge)`` to a list of m/z values.
@@ -3349,6 +3363,8 @@ class ProFormaAnnotation:
         :raises ValueError: If a meta ion type (``W``, ``D``) is requested, or if the
             annotation contains unknown mods or interval mods.
         """
+        if charges is None:
+            charges = self._default_fragment_charges(self.charge_state)
         for ion_type_input in ion_types:
             if IonType(ion_type_input) in self._UNSUPPORTED_META_ION_TYPES:
                 raise ValueError(
@@ -3366,12 +3382,13 @@ class ProFormaAnnotation:
                 ion_info: FragmentIonInfo = FRAGMENT_ION_LOOKUP[ion_type]
                 ion_offset = ion_info.get_mass(monoisotopic=monoisotopic)
 
+                abs_charge = abs(charge)
                 if ion_info.is_forward:
                     prefix = 0.0
                     masses_out: list[float] = []
                     for m in mass_vec:
                         prefix += m
-                        masses_out.append((prefix + ion_offset + charge_offset) / charge)
+                        masses_out.append((prefix + ion_offset + charge_offset) / abs_charge)
                     result[(ion_type, charge)] = masses_out
 
                 elif ion_info.is_backward:
@@ -3379,16 +3396,16 @@ class ProFormaAnnotation:
                     masses_out = []
                     for i in range(n - 1, -1, -1):
                         prefix += mass_vec[i]
-                        masses_out.append((prefix + ion_offset + charge_offset) / charge)
+                        masses_out.append((prefix + ion_offset + charge_offset) / abs_charge)
                     result[(ion_type, charge)] = masses_out
 
                 elif ion_info.is_intact:
                     total = sum(mass_vec)
-                    mz = (total + ion_offset + charge_offset) / charge
+                    mz = (total + ion_offset + charge_offset) / abs_charge
                     result[(ion_type, charge)] = [mz] * n
 
                 elif ion_info.is_internal:
-                    result[(ion_type, charge)] = [(mass_vec[i] + ion_offset + charge_offset) / charge for i in range(n)]
+                    result[(ion_type, charge)] = [(mass_vec[i] + ion_offset + charge_offset) / abs_charge for i in range(n)]
 
         return result
 

--- a/src/peptacular/annotation/frag.py
+++ b/src/peptacular/annotation/frag.py
@@ -1,11 +1,13 @@
 from collections import Counter
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
 from tacular import (
     ELEMENT_LOOKUP,
+    FRAGMENT_ION_LOOKUP,
     ElementInfo,
     IonType,
+    IonTypeProperty,
 )
 
 from ..constants import ModType
@@ -15,6 +17,34 @@ from ..proforma_components import (
 )
 from .mod import Mods
 from .positions import validate_position
+
+# Maps internal ion type value tuples to their neutral loss diff relative to "by" (the default internal fragment).
+# None means no difference from "by".
+_INTERNAL_MASS_DIFFS: dict[tuple[str, str], str | None] = {
+    ("a", "x"): None,
+    ("b", "x"): "+CO",
+    ("c", "x"): "+CHNO",
+    ("a", "y"): "-CO",
+    ("b", "y"): None,
+    ("c", "y"): "+NH",
+    ("a", "z"): "-CHNO",
+    ("b", "z"): "-NH",
+    ("c", "z"): None,
+}
+
+# Maps peptacular variant ion types to their canonical mzPAF series string.
+_ION_TYPE_TO_MZPAF_SERIES: dict[IonType, str] = {
+    IonType.W_VALINE: "w",
+    IonType.D_VALINE: "d",
+    IonType.WB_ISOLEUCINE: "wb",
+    IonType.WB_THREONINE: "wb",
+    IonType.WA_ISOLEUCINE: "wa",
+    IonType.WA_THREONINE: "wa",
+    IonType.DB_ISOLEUCINE: "db",
+    IonType.DB_THREONINE: "db",
+    IonType.DA_ISOLEUCINE: "da",
+    IonType.DA_THREONINE: "da",
+}
 
 
 class Fragment:
@@ -143,6 +173,158 @@ class Fragment:
             "isotopes": self.isotopes,
             "losses": self.losses,
         }
+
+    def serialize(self, format: Literal["default", "mzpaf"] = "default", include_sequence: bool = True) -> str:
+        """Serialize the fragment to a string representation.
+
+        :param format: Output format. ``"default"`` returns the human-readable representation,
+            ``"mzpaf"`` returns the mzPAF (Peak Annotation Format) label string.
+        :type format: Literal["default", "mzpaf"]
+        :param include_sequence: If True, include the peptide sequence in the mzPAF label. Only used for ``"mzpaf"`` format.
+        :type include_sequence: bool
+        :return: The serialized fragment string.
+        :rtype: str
+        """
+        if format == "default":
+            return str(self)
+        elif format == "mzpaf":
+            return self._serialize_mzpaf(include_sequence=include_sequence)
+        else:
+            raise ValueError(f"Unknown format: {format!r}. Use 'default' or 'mzpaf'.")
+
+    def to_mzpaf(self, include_sequence: bool = True) -> str:
+        """Serialize the fragment to an mzPAF (Peak Annotation Format) label string.
+
+        :param include_sequence: If True, include the peptide sequence in the label.
+        :type include_sequence: bool
+        :return: The mzPAF label string (e.g. ``"y3{IDE}^2"``).
+        :rtype: str
+        """
+        return self._serialize_mzpaf(include_sequence=include_sequence)
+
+    def _serialize_mzpaf(self, include_sequence: bool = True) -> str:
+        """Build the mzPAF label string for this fragment."""
+        from .annotation import ProFormaAnnotation
+
+        parts: list[str] = []
+        internal_loss: str | None = None
+
+        if self.ion_type is None:
+            parts.append("?")
+        else:
+            ion_info = FRAGMENT_ION_LOOKUP[self.ion_type]
+
+            if ion_info.properties & (IonTypeProperty.FORWARD | IonTypeProperty.BACKWARD):
+                # Peptide series ions (a, b, c, x, y, z, d, w, da, db, wa, wb)
+                series_str = _ION_TYPE_TO_MZPAF_SERIES.get(ion_info.ion_type, ion_info.ion_type.value)
+                position = self.position if isinstance(self.position, int) else -1
+                parts.append(f"{series_str}{position}")
+
+                if include_sequence and self.parent_sequence is not None:
+                    seq = self.sequence
+                    if seq is not None:
+                        seq_no_charge = ProFormaAnnotation.parse(seq).serialize(exclude_charge=True)
+                        parts.append(f"{{{seq_no_charge}}}")
+
+            elif ion_info.properties & IonTypeProperty.INTERNAL:
+                if ion_info.id == IonType.IMMONIUM:
+                    # Immonium ion: I{amino_acid}[{modification}]
+                    if self.parent_sequence is not None:
+                        seq = self.sequence
+                        if seq is not None:
+                            annot = ProFormaAnnotation.parse(seq)
+                            parts.append(f"I{annot.sequence}")
+
+                            if annot.has_internal_mods_at_index(0):
+                                internal_mods = annot.get_internal_mods_at_index(0)
+                                if len(internal_mods) > 1:
+                                    raise ValueError(f"Multiple internal mods on immonium ion not supported in mzPAF, got {internal_mods}")
+                                if len(internal_mods) == 1 and internal_mods.mods[0].count > 1:
+                                    raise ValueError(f"Multiple occurrences of internal mod on immonium ion not supported in mzPAF, got {internal_mods}")
+                                mods_str = internal_mods.serialize()[1:-1]  # remove surrounding brackets
+                                if mods_str == "":
+                                    raise ValueError(f"Empty modification string for immonium ion is not valid in mzPAF. Internal mods: {internal_mods}")
+                                parts.append(f"[{mods_str}]")
+                        else:
+                            raise ValueError("Immonium ion must have a sequence annotation.")
+                    else:
+                        raise ValueError("Immonium ion must have a parent sequence.")
+                else:
+                    # Internal fragment: m{start}:{end}[{sequence}]
+                    if isinstance(self.position, tuple) and len(self.position) == 2:
+                        start, end = self.position
+                    else:
+                        start, end = -1, -1
+
+                    parts.append(f"m{start}:{end}")
+
+                    if include_sequence and self.parent_sequence is not None:
+                        seq = self.sequence
+                        if seq is not None:
+                            seq_no_charge = ProFormaAnnotation.parse(seq).serialize(exclude_charge=True)
+                            parts.append(f"{{{seq_no_charge}}}")
+
+                    # Add internal mass diff neutral loss
+                    internal_ion_key = tuple(list(ion_info.ion_type.value))
+                    if internal_ion_key in _INTERNAL_MASS_DIFFS:
+                        internal_loss = _INTERNAL_MASS_DIFFS[internal_ion_key]
+                    else:
+                        raise ValueError(f"Internal ion type {ion_info.ion_type} not supported in mzPAF.")
+
+            elif ion_info.properties & IonTypeProperty.INTACT:
+                if ion_info.ion_type == IonType.PRECURSOR:
+                    parts.append("p")
+                else:
+                    raise ValueError(f"Cannot convert intact ion type {ion_info.id} to mzPAF.")
+            else:
+                raise ValueError(f"Cannot convert fragment with ion type {self.ion_type} to mzPAF.")
+
+        # Neutral losses from self.losses
+        if self._losses is not None:
+            for loss_key, count in self._losses.items():
+                if isinstance(loss_key, float | int):
+                    mass_val = float(loss_key) * count
+                    parts.append(f"{mass_val:+.5f}")
+                else:
+                    loss_formula = ChargedFormula.from_string(loss_key, require_formula_prefix=False)
+                    paf_formula = loss_formula.to_mz_paf()
+                    sign = paf_formula[0]
+                    if sign not in ("+", "-"):
+                        raise ValueError(f"Invalid formula sign in loss: {paf_formula}")
+                    mult = 1 if sign == "+" else -1
+                    abs_count = abs(count * mult)
+                    count_str = str(abs_count) if abs_count > 1 else ""
+                    parts.append(f"{sign}{count_str}{paf_formula[1:]}")
+
+        # Internal mass diff loss (from internal fragment type)
+        if internal_loss is not None:
+            parts.append(internal_loss)
+
+        # Isotopes
+        if self._isotopes is not None:
+            if isinstance(self._isotopes, int):
+                count_str = str(self._isotopes) if self._isotopes > 1 else ""
+                parts.append(f"+{count_str}i")
+            elif isinstance(self._isotopes, dict):
+                for elem, count in self._isotopes.items():
+                    count_str = str(count) if count > 1 else ""
+                    parts.append(f"+{count_str}i{elem}")
+
+        # Adducts
+        if self._charge_adducts is not None:
+            adduct_parts: list[str] = []
+            for mod in self.charge_adducts.mods:
+                carrier: GlobalChargeCarrier = mod.value
+                # to_mz_paf() returns "M+Na", we strip the "M" prefix
+                paf_str = carrier.to_mz_paf()
+                adduct_parts.append(paf_str[1:])  # strip "M", keep "+Na"
+            parts.append(f"[M{''.join(adduct_parts)}]")
+
+        # Charge (only if > 1)
+        if self.charge_state > 1:
+            parts.append(f"^{self.charge_state}")
+
+        return "".join(parts)
 
     def __str__(self) -> str:
         parts = []

--- a/src/peptacular/annotation/frag.py
+++ b/src/peptacular/annotation/frag.py
@@ -101,7 +101,7 @@ class Fragment:
 
     @property
     def mz(self) -> float:
-        return self.mass / self.charge_state if self.charge_state != 0 else self.mass
+        return self.mass / abs(self.charge_state) if self.charge_state != 0 else self.mass
 
     @property
     def neutral_mass(self) -> float:
@@ -320,8 +320,8 @@ class Fragment:
                 adduct_parts.append(paf_str[1:])  # strip "M", keep "+Na"
             parts.append(f"[M{''.join(adduct_parts)}]")
 
-        # Charge (only if > 1)
-        if self.charge_state > 1:
+        # Charge: omit for +1 (implicit); include for everything else
+        if self.charge_state != 0 and self.charge_state != 1:
             parts.append(f"^{self.charge_state}")
 
         return "".join(parts)

--- a/src/peptacular/annotation/frag.py
+++ b/src/peptacular/annotation/frag.py
@@ -55,9 +55,18 @@ class Fragment:
         if self.parent_sequence is None:
             raise ValueError("Cannot calculate composition without parent sequence or explicit composition")
 
+        if self.parent_sequence_length is None:
+            raise ValueError("Cannot calculate composition without parent sequence length")
+
         from .annotation import ProFormaAnnotation
 
         annot = ProFormaAnnotation.parse(self.parent_sequence)
+
+        pos = validate_position(self.ion_type, self.position, self.parent_sequence_length)
+        if pos is not None:
+            start, end = pos
+            annot = annot[slice(start, end)]
+
         return annot.comp(isotopes=self.isotopes, deltas=self.losses, charge=self.charge_state if self._charge_adducts is None else self.charge_adducts)  # type: ignore
 
     @property

--- a/src/peptacular/sequence/__init__.py
+++ b/src/peptacular/sequence/__init__.py
@@ -47,7 +47,7 @@ from .digestion import (
     simple_cleavage_sites,
     simple_digest,
 )
-from .fragmentation import frag, fragment, fragment_masses
+from .fragmentation import fast_fragment, frag, fragment
 from .isotope import isotopic_distribution
 from .mass_funcs import comp, mass, mz
 from .mod_builder import (
@@ -150,7 +150,7 @@ __all__ = [
     "simple_cleavage_sites",
     # fragmentation
     "fragment",
-    "fragment_masses",
+    "fast_fragment",
     # mass_funcs
     "mass",
     "mz",

--- a/src/peptacular/sequence/fragmentation.py
+++ b/src/peptacular/sequence/fragmentation.py
@@ -224,14 +224,14 @@ def frag(
         )
 
 
-def _fragment_masses_single(
+def _fast_fragment_single(
     sequence: str | ProFormaAnnotation,
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
     charges: Sequence[int] = (1,),
     monoisotopic: bool = True,
 ) -> FRAGMENT_MASSES_RETURN:
     annotation = get_annotation_input(sequence=sequence, copy=False)
-    return annotation.fragment_masses(
+    return annotation.fast_fragment(
         ion_types=ion_types,
         charges=charges,
         monoisotopic=monoisotopic,
@@ -239,7 +239,7 @@ def _fragment_masses_single(
 
 
 @overload
-def fragment_masses(
+def fast_fragment(
     sequence: str | ProFormaAnnotation,
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
     charges: Sequence[int] = (1,),
@@ -251,7 +251,7 @@ def fragment_masses(
 
 
 @overload
-def fragment_masses(
+def fast_fragment(
     sequence: Sequence[str | ProFormaAnnotation],
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
     charges: Sequence[int] = (1,),
@@ -262,7 +262,7 @@ def fragment_masses(
 ) -> list[FRAGMENT_MASSES_RETURN]: ...
 
 
-def fragment_masses(
+def fast_fragment(
     sequence: str | ProFormaAnnotation | Sequence[str | ProFormaAnnotation],
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
     charges: Sequence[int] = (1,),
@@ -280,7 +280,7 @@ def fragment_masses(
     """
     if isinstance(sequence, Sequence) and not isinstance(sequence, str) and not isinstance(sequence, ProFormaAnnotation):
         return parallel_apply_internal(
-            _fragment_masses_single,
+            _fast_fragment_single,
             sequence,
             n_workers=n_workers,
             chunksize=chunksize,
@@ -290,7 +290,7 @@ def fragment_masses(
             monoisotopic=monoisotopic,
         )
     else:
-        return _fragment_masses_single(
+        return _fast_fragment_single(
             sequence=sequence,
             ion_types=ion_types,
             charges=charges,

--- a/src/peptacular/sequence/fragmentation.py
+++ b/src/peptacular/sequence/fragmentation.py
@@ -227,7 +227,7 @@ def frag(
 def _fast_fragment_single(
     sequence: str | ProFormaAnnotation,
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
-    charges: Sequence[int] = (1,),
+    charges: Sequence[int] | None = None,
     monoisotopic: bool = True,
 ) -> FRAGMENT_MASSES_RETURN:
     annotation = get_annotation_input(sequence=sequence, copy=False)
@@ -242,7 +242,7 @@ def _fast_fragment_single(
 def fast_fragment(
     sequence: str | ProFormaAnnotation,
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
-    charges: Sequence[int] = (1,),
+    charges: Sequence[int] | None = None,
     monoisotopic: bool = True,
     n_workers: None = None,
     chunksize: None = None,
@@ -254,7 +254,7 @@ def fast_fragment(
 def fast_fragment(
     sequence: Sequence[str | ProFormaAnnotation],
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
-    charges: Sequence[int] = (1,),
+    charges: Sequence[int] | None = None,
     monoisotopic: bool = True,
     n_workers: int | None = None,
     chunksize: int | None = None,
@@ -265,7 +265,7 @@ def fast_fragment(
 def fast_fragment(
     sequence: str | ProFormaAnnotation | Sequence[str | ProFormaAnnotation],
     ion_types: Sequence[ION_TYPE] = (IonType.B, IonType.Y),
-    charges: Sequence[int] = (1,),
+    charges: Sequence[int] | None = None,
     monoisotopic: bool = True,
     n_workers: int | None = None,
     chunksize: int | None = None,

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -706,5 +706,88 @@ class TestFragment(unittest.TestCase):
         self.assertAlmostEqual(frags[2].mz, pt.mz("P/2", ion_type="by"))
 
 
+class TestFragmentMzPAF(unittest.TestCase):
+    """Test mzPAF serialization of Fragment objects."""
+
+    def test_b_ion_full(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.B, charge=2)
+        self.assertEqual(frag.to_mzpaf(), "b7{PEPTIDE}^2")
+
+    def test_b_ion_position(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.B, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "b3{PEP}^2")
+
+    def test_y_ion_position(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "y3{IDE}^2")
+
+    def test_y_ion_charge_1(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        self.assertEqual(frag.to_mzpaf(), "y3{IDE}")
+
+    def test_immonium(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.IMMONIUM, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "IP^2")
+
+    def test_immonium_with_mod(self):
+        frag = pt.parse("PEP[+10]TIDE/2").frag(ion_type=pt.IonType.IMMONIUM, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(), "IP[+10]^2")
+
+    def test_internal_by(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.BY, charge=2, position=(3, 5))
+        self.assertEqual(frag.to_mzpaf(), "m3:5{PTI}^2")
+
+    def test_internal_ay(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.AY, charge=2, position=(3, 5))
+        self.assertEqual(frag.to_mzpaf(), "m3:5{PTI}-CO^2")
+
+    def test_precursor(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.PRECURSOR, charge=2)
+        self.assertEqual(frag.to_mzpaf(), "p^2")
+
+    def test_no_sequence(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.to_mzpaf(include_sequence=False), "y3^2")
+
+    def test_adduct(self):
+        frags = pt.parse("PEPTIDE/2").fragment(ion_types=["y"], charges=["Na:z+1"])
+        self.assertIn("[M+Na]", frags[0].to_mzpaf())
+
+    def test_isotope_c13(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[1])
+        self.assertIn("+i", frags[0].to_mzpaf())
+
+    def test_isotope_c13_x2(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[2])
+        self.assertIn("+2i", frags[0].to_mzpaf())
+
+    def test_isotope_custom(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], isotopes=[{"17O": 2}])
+        self.assertIn("+2i17O", frags[0].to_mzpaf())
+
+    def test_neutral_loss(self):
+        frags = pt.parse("PEPTIDE/1").fragment(ion_types=["y"], charges=[1], neutral_deltas=["H2O"])
+        labels = [f.to_mzpaf() for f in frags]
+        self.assertTrue(any("-H2O" in label for label in labels))
+
+    def test_serialize_format_default(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        self.assertEqual(frag.serialize(format="default"), str(frag))
+
+    def test_serialize_format_mzpaf(self):
+        frag = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.Y, charge=2, position=3)
+        self.assertEqual(frag.serialize(format="mzpaf"), "y3{IDE}^2")
+
+    def test_serialize_invalid_format(self):
+        frag = pt.parse("PEPTIDE/1").frag(ion_type=pt.IonType.Y, charge=1, position=3)
+        with self.assertRaises(ValueError):
+            frag.serialize(format="invalid")
+
+    def test_modification_in_sequence(self):
+        frag = pt.parse("PEPT[Phospho]IDE/2").frag(ion_type=pt.IonType.B, charge=2, position=4)
+        label = frag.to_mzpaf()
+        self.assertEqual(label, "b4{PEPT[Phospho]}^2")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -643,67 +643,89 @@ class TestFragment(unittest.TestCase):
             )
 
     def test_fragmenty(self):
+        # /2 precursor → default charges are [1] (range 1..charge-1)
         annot = pt.parse("PEPTIDE/2")
 
         frags = annot.fragment(ion_types=["y"])
         self.assertEqual(len(frags), 7)
         self.assertEqual(frags[0].position, 1)
-        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/2")
-        self.assertEqual(frags[0].charge_state, 2)
-        self.assertEqual(frags[0].sequence, "E/2")
-        self.assertAlmostEqual(frags[0].mz, pt.mz("E/2", ion_type="y"))
+        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/1")
+        self.assertEqual(frags[0].charge_state, 1)
+        self.assertEqual(frags[0].sequence, "E/1")
+        self.assertAlmostEqual(frags[0].mz, pt.mz("E/1", ion_type="y"))
 
     def test_fragmentb(self):
+        # /2 precursor → default charges are [1] (range 1..charge-1)
         annot = pt.parse("PEPTIDE/2")
 
         frags = annot.fragment(ion_types=["b"])
         self.assertEqual(len(frags), 7)
         self.assertEqual(frags[0].position, 1)
-        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/2")
-        self.assertEqual(frags[0].charge_state, 2)
-        self.assertEqual(frags[0].sequence, "P/2")
-        self.assertAlmostEqual(frags[0].mz, pt.mz("P/2", ion_type="b"))
+        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/1")
+        self.assertEqual(frags[0].charge_state, 1)
+        self.assertEqual(frags[0].sequence, "P/1")
+        self.assertAlmostEqual(frags[0].mz, pt.mz("P/1", ion_type="b"))
 
     def test_fragment_immonium(self):
+        # /2 precursor → default charges are [1] (range 1..charge-1)
         annot = pt.parse("PEPTIDE/2")
 
         frags = annot.fragment(ion_types=["i"])
         self.assertEqual(len(frags), 7)
         self.assertEqual(frags[0].position, 1)
-        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/2")
-        self.assertEqual(frags[0].charge_state, 2)
-        self.assertEqual(frags[0].sequence, "P/2")
-        self.assertAlmostEqual(frags[0].mz, pt.mz("P/2", ion_type="i"))
+        self.assertEqual(frags[0].parent_sequence, "PEPTIDE/1")
+        self.assertEqual(frags[0].charge_state, 1)
+        self.assertEqual(frags[0].sequence, "P/1")
+        self.assertAlmostEqual(frags[0].mz, pt.mz("P/1", ion_type="i"))
 
         self.assertEqual(frags[1].position, 2)
-        self.assertEqual(frags[1].parent_sequence, "PEPTIDE/2")
-        self.assertEqual(frags[1].charge_state, 2)
-        self.assertEqual(frags[1].sequence, "E/2")
-        self.assertAlmostEqual(frags[1].mz, pt.mz("E/2", ion_type="i"))
+        self.assertEqual(frags[1].parent_sequence, "PEPTIDE/1")
+        self.assertEqual(frags[1].charge_state, 1)
+        self.assertEqual(frags[1].sequence, "E/1")
+        self.assertAlmostEqual(frags[1].mz, pt.mz("E/1", ion_type="i"))
 
     def test_fragment_internal(self):
+        # /2 precursor → default charges are [1] (range 1..charge-1)
         annot = pt.parse("PEPT/2")
 
         frags = annot.fragment(ion_types=["by"])
         self.assertEqual(len(frags), 3)  # EP, E, P
 
         self.assertEqual(frags[0].position, (2, 2))
-        self.assertEqual(frags[0].parent_sequence, "PEPT/2")
-        self.assertEqual(frags[0].charge_state, 2)
-        self.assertEqual(frags[0].sequence, "E/2")
-        self.assertAlmostEqual(frags[0].mz, pt.mz("E/2", ion_type="by"))
+        self.assertEqual(frags[0].parent_sequence, "PEPT/1")
+        self.assertEqual(frags[0].charge_state, 1)
+        self.assertEqual(frags[0].sequence, "E/1")
+        self.assertAlmostEqual(frags[0].mz, pt.mz("E/1", ion_type="by"))
 
         self.assertEqual(frags[1].position, (2, 3))
-        self.assertEqual(frags[1].parent_sequence, "PEPT/2")
-        self.assertEqual(frags[1].charge_state, 2)
-        self.assertEqual(frags[1].sequence, "EP/2")
-        self.assertAlmostEqual(frags[1].mz, pt.mz("EP/2", ion_type="by"))
+        self.assertEqual(frags[1].parent_sequence, "PEPT/1")
+        self.assertEqual(frags[1].charge_state, 1)
+        self.assertEqual(frags[1].sequence, "EP/1")
+        self.assertAlmostEqual(frags[1].mz, pt.mz("EP/1", ion_type="by"))
 
         self.assertEqual(frags[2].position, (3, 3))
-        self.assertEqual(frags[2].parent_sequence, "PEPT/2")
-        self.assertEqual(frags[2].charge_state, 2)
-        self.assertEqual(frags[2].sequence, "P/2")
-        self.assertAlmostEqual(frags[2].mz, pt.mz("P/2", ion_type="by"))
+        self.assertEqual(frags[2].parent_sequence, "PEPT/1")
+        self.assertEqual(frags[2].charge_state, 1)
+        self.assertEqual(frags[2].sequence, "P/1")
+        self.assertAlmostEqual(frags[2].mz, pt.mz("P/1", ion_type="by"))
+
+    def test_fragment_default_charges_range(self):
+        # /3 precursor → default charges [1, 2]
+        frags3 = pt.parse("PEPTIDE/3").fragment(ion_types=["b"])
+        charges3 = sorted({f.charge_state for f in frags3})
+        self.assertEqual(charges3, [1, 2])
+
+        # /2 precursor → default charges [1]
+        frags2 = pt.parse("PEPTIDE/2").fragment(ion_types=["b"])
+        self.assertTrue(all(f.charge_state == 1 for f in frags2))
+
+        # no charge annotation → last-resort [1]
+        frags0 = pt.parse("PEPTIDE").fragment(ion_types=["b"])
+        self.assertTrue(all(f.charge_state == 1 for f in frags0))
+
+        # user-supplied charges always win
+        frags_exp = pt.parse("PEPTIDE/3").fragment(ion_types=["b"], charges=[2])
+        self.assertTrue(all(f.charge_state == 2 for f in frags_exp))
 
 
 class TestFragmentMzPAF(unittest.TestCase):
@@ -787,6 +809,31 @@ class TestFragmentMzPAF(unittest.TestCase):
         frag = pt.parse("PEPT[Phospho]IDE/2").frag(ion_type=pt.IonType.B, charge=2, position=4)
         label = frag.to_mzpaf()
         self.assertEqual(label, "b4{PEPT[Phospho]}^2")
+
+    def test_negative_charge_z_minus_1(self):
+        frag = pt.parse("PEPTIDE/-2").frag(ion_type=pt.IonType.B, charge=-1, position=3)
+        self.assertEqual(frag.charge_state, -1)
+        self.assertGreater(frag.mz, 0)
+        self.assertEqual(frag.to_mzpaf(), "b3{PEP}^-1")
+        self.assertEqual(frag.serialize(format="mzpaf"), "b3{PEP}^-1")
+
+    def test_negative_charge_z_minus_2(self):
+        frag = pt.parse("PEPTIDE/-3").frag(ion_type=pt.IonType.B, charge=-2, position=3)
+        self.assertEqual(frag.charge_state, -2)
+        self.assertGreater(frag.mz, 0)
+        self.assertEqual(frag.to_mzpaf(), "b3{PEP}^-2")
+
+    def test_negative_charge_y_ion(self):
+        frag = pt.parse("PEPTIDE/-2").frag(ion_type=pt.IonType.Y, charge=-1, position=3)
+        self.assertEqual(frag.charge_state, -1)
+        self.assertGreater(frag.mz, 0)
+        self.assertEqual(frag.to_mzpaf(), "y3{IDE}^-1")
+
+    def test_negative_charge_mz_less_than_positive(self):
+        # Negative-mode b3 loses a proton; positive-mode adds one — so neg mz < pos mz
+        frag_pos = pt.parse("PEPTIDE/2").frag(ion_type=pt.IonType.B, charge=1, position=3)
+        frag_neg = pt.parse("PEPTIDE/-2").frag(ion_type=pt.IonType.B, charge=-1, position=3)
+        self.assertAlmostEqual(frag_pos.mz - frag_neg.mz, 2 * 1.007276, places=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces a new high-performance fragment ion calculation method for MS/MS analysis, refines charge handling for negative ions, and improves the API for fragment-related computations. The main focus is on enabling fast, batch-friendly fragment m/z calculations and clarifying charge state behavior, especially for negative charges. Documentation and example scripts are updated to showcase these changes.

**Major new feature: Fast fragment ion calculation**

* Added the `fast_fragment()` method to `ProFormaAnnotation`, which uses a prefix/suffix-sum algorithm to rapidly compute fragment m/z values without constructing `Fragment` objects. This method is optimized for high-throughput workflows and supports both OOP and functional APIs, including batch processing. It does not support neutral losses, isotope shifts, adduct charges, or custom deltas. Documentation and usage examples are provided in both `docs/features.rst` and `examples/fragment.py`. [[1]](diffhunk://#diff-007ad9483fe1626db5e93341261528b080cefe252e0f12608764fe856edc3000R57-R76) [[2]](diffhunk://#diff-7a0cf40aa7f38043b0c30dd82c1056fd3f712009461fb657b6272df82efb0125L234-R283) [[3]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L3327-R3342)

**Charge state and adduct handling improvements**

* Enhanced `charge_adducts` property in `ProFormaAnnotation` to support both protonation (positive charge) and deprotonation (negative charge) adducts, ensuring correct handling of negative charge states. Introduced `H_DECHARGE_FORMULA` for deprotonation. [[1]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6R120) [[2]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L843-R859)
* All fragment m/z calculations now use the absolute value of the charge state, ensuring correct results for negative charges. [[1]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6R3385-R3408) [[2]](diffhunk://#diff-15f3b09d735f004b4b2bcf61c07ac55d04ffaa35f1580ba00d3e887e2cc6b205R88-R104)

**API and usability improvements**

* The default fragment charge states are now determined by the precursor charge: for positive charges, fragments default to 1, 2, ..., (precursor charge - 1); for negative charges, to -1, -2, ..., (precursor charge + 1); and fallback to 1 for unannotated or ±1 charge. This logic is encapsulated in `_default_fragment_charges`. [[1]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6R3263-R3276) [[2]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L3278-R3294) [[3]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L3343-R3371)
* Renamed `fragment_masses()` to `fast_fragment()` for clarity and consistency. Improved error messages and parameter documentation, especially regarding unsupported ion types and sequence modifications. [[1]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L2738-R2740) [[2]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L3343-R3371)

**Documentation and example updates**

* Updated `docs/features.rst` and `examples/fragment.py` to describe and demonstrate the new `fast_fragment()` method, including its limitations and usage patterns for both single and batch inputs. [[1]](diffhunk://#diff-007ad9483fe1626db5e93341261528b080cefe252e0f12608764fe856edc3000R57-R76) [[2]](diffhunk://#diff-7a0cf40aa7f38043b0c30dd82c1056fd3f712009461fb657b6272df82efb0125L234-R283)
* Minor improvements and clarifications in docstrings and error messages throughout the codebase. [[1]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L2738-R2740) [[2]](diffhunk://#diff-28b3c82a50a99cc7b9c30dcd1db959a37b85d73f4c35641c6f880a6fcda0e9a6L3343-R3371)

**Other changes**

* Bumped the package version to `3.1.1` in `src/peptacular/__init__.py`.
* Added new internal mappings and canonicalization logic for ion types in `frag.py`, improving support for mzPAF serialization and internal ion mass differences. [[1]](diffhunk://#diff-15f3b09d735f004b4b2bcf61c07ac55d04ffaa35f1580ba00d3e887e2cc6b205L3-R10) [[2]](diffhunk://#diff-15f3b09d735f004b4b2bcf61c07ac55d04ffaa35f1580ba00d3e887e2cc6b205R21-R48)

These changes collectively enhance the performance, flexibility, and clarity of fragment ion calculations in the library, especially for users working with large-scale or high-throughput MS/MS data.